### PR TITLE
Add client-side tracking for watched videos

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -7,6 +7,19 @@ const { findNavigationEntries } = require('@11ty/eleventy-navigation/eleventy-na
 
 const moment = require('moment');
 
+const slugifyValue = (value = '') => value
+  .toString()
+  .toLowerCase()
+  .replace(/[^a-z0-9]+/g, '-')
+  .replace(/(^-|-$)/g, '');
+
+const makeVideoAnchor = (videoSource, pageUrl = '') => {
+  const pagePart = slugifyValue(pageUrl);
+  const sourcePart = slugifyValue(videoSource);
+  const parts = [pagePart, sourcePart].filter(Boolean);
+  return parts.length ? `video-${parts.join('-')}` : '';
+};
+
 module.exports = function(config) {
 
   // A useful way to reference the context we are runing eleventy in
@@ -39,6 +52,7 @@ module.exports = function(config) {
 
         const [url = "", poster = "", captionFile = "", dgUrl = ""] = stringArgs;
         const source = locale === "dg" && dgUrl ? dgUrl : url;
+        const anchorId = makeVideoAnchor(source, pageMeta.url);
 
         videos.push({
           locale,
@@ -46,6 +60,7 @@ module.exports = function(config) {
           pageTitle: pageMeta.title,
           videoId: source,
           videoSrc: source,
+          anchorId,
           poster,
           captionFile,
         });
@@ -87,6 +102,7 @@ module.exports = function(config) {
   config.addPlugin(eleventyNavigationPlugin);
 
   config.addFilter('videosByLocale', (videos, locale) => (videos || []).filter(video => video.locale === locale));
+  config.addFilter('videoAnchor', (videoSource, pageUrl = '') => makeVideoAnchor(videoSource, pageUrl));
 
   config.addPlugin(pluginTOC, {
     tags: ['h2'],

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -61,7 +61,7 @@ module.exports = function(config) {
 
         const [url = "", poster = "", captionFile = "", captionLabel = "", localeArg = "", dgUrl = ""] = stringArgs;
         const source = locale === "dg" && dgUrl ? dgUrl : url;
-        const anchorId = makeVideoAnchor(source, pageMeta.url);
+        const anchorId = makeVideoAnchor(source);
 
         videos.push({
           locale,

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -49,7 +49,10 @@ module.exports = function(config) {
 
       for (const match of content.matchAll(tokenRegex)) {
         const [, macroName, args] = match;
-        const stringArgs = Array.from(args.matchAll(/"([^"]*)"/g), arg => arg[1]);
+        const stringArgs = Array.from(
+          args.matchAll(/['"]([^'"\\]*(?:\\.[^'"\\]*)*)['"]/g),
+          arg => arg[1].replace(/\\(['"])/g, '$1')
+        );
 
         if (!stringArgs.length) continue;
 

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -2,6 +2,8 @@
 const syntaxHighlight = require("@11ty/eleventy-plugin-syntaxhighlight");
 const eleventyNavigationPlugin = require("@11ty/eleventy-navigation");
 const pluginTOC = require('eleventy-plugin-toc');
+const fs = require('fs');
+const { findNavigationEntries } = require('@11ty/eleventy-navigation/eleventy-navigation');
 
 const moment = require('moment');
 
@@ -15,6 +17,65 @@ module.exports = function(config) {
     return collection.getFilteredByGlob("./src/site/code/3d/*.md");
   });
 
+  config.addCollection("videoLibrary", function(collectionApi) {
+    const navEntries = findNavigationEntries(collectionApi.getAll());
+    const entriesByUrl = new Map();
+
+    collectionApi.getAll().forEach(item => {
+      if (item.url) {
+        entriesByUrl.set(item.url, item);
+      }
+    });
+
+    const locales = new Set(["de", "en", "dg"]);
+    const videos = [];
+
+    const extractVideos = (content, locale, pageMeta) => {
+      const matches = content.matchAll(/{{\s*video\((.*?)\)\s*}}/gs);
+
+      for (const match of matches) {
+        const stringArgs = Array.from(match[1].matchAll(/"([^"]*)"/g), arg => arg[1]);
+        if (!stringArgs.length) continue;
+
+        const [url = "", poster = "", captionFile = "", dgUrl = ""] = stringArgs;
+        const source = locale === "dg" && dgUrl ? dgUrl : url;
+
+        videos.push({
+          locale,
+          pageUrl: pageMeta.url,
+          pageTitle: pageMeta.title,
+          videoId: source,
+          videoSrc: source,
+          poster,
+          captionFile,
+        });
+      }
+    };
+
+    const walkNav = entry => {
+      const page = entriesByUrl.get(entry.url);
+      if (page && locales.has(page.data.locale)) {
+        try {
+          const content = fs.readFileSync(page.inputPath, 'utf-8');
+          extractVideos(content, page.data.locale, {
+            url: entry.url,
+            title: entry.title || page.data.title || page.fileSlug,
+          });
+        } catch (error) {
+          console.warn(`Unable to read content for video extraction: ${entry.url}`, error);
+        }
+      }
+
+      if (entry.children?.length) {
+        entry.children.forEach(walkNav);
+      }
+    };
+
+    navEntries.forEach(root => walkNav(root));
+
+    return videos;
+  });
+
   // Layout aliases can make templates more portable
   config.addLayoutAlias('default', 'layouts/base.njk');
   config.addLayoutAlias('home', 'layouts/home.njk');
@@ -24,6 +85,8 @@ module.exports = function(config) {
 
   // add navigation data object
   config.addPlugin(eleventyNavigationPlugin);
+
+  config.addFilter('videosByLocale', (videos, locale) => (videos || []).filter(video => video.locale === locale));
 
   config.addPlugin(pluginTOC, {
     tags: ['h2'],

--- a/src/site/_includes/layouts/base.njk
+++ b/src/site/_includes/layouts/base.njk
@@ -5,7 +5,7 @@
 <!DOCTYPE html>
 <html lang="{% if locale == "de" %}de-DE{% elif locale == "dg" %}sgn-DE{% else %}en-US{% endif %}">
   {% include 'parts/head.njk' %}
-  <body>
+  <body class="{% if page.fileSlug == 'videos' %}video-library-page{% endif %}">
     <a tabindex="0" id="skip-nav" href="#content-start">{{ translations.skipContent[locale]|safe }}</a>
     <header id="header" role="banner">
       <div>

--- a/src/site/_includes/layouts/base.njk
+++ b/src/site/_includes/layouts/base.njk
@@ -5,7 +5,7 @@
 <!DOCTYPE html>
 <html lang="{% if locale == "de" %}de-DE{% elif locale == "dg" %}sgn-DE{% else %}en-US{% endif %}">
   {% include 'parts/head.njk' %}
-  <body class="{% if page.fileSlug == 'videos' %}video-library-page{% endif %}">
+  <body>
     <a tabindex="0" id="skip-nav" href="#content-start">{{ translations.skipContent[locale]|safe }}</a>
     <header id="header" role="banner">
       <div>

--- a/src/site/_includes/parts/macros.njk
+++ b/src/site/_includes/parts/macros.njk
@@ -105,7 +105,11 @@
 {% endmacro %}
 
 {% macro video(url, poster, captionFile, captionLabel, locale, dgUrl="") %}
-{% set videoSource = locale == "dg" and dgUrl ? dgUrl : url %}
+{% if locale == "dg" and dgUrl %}
+  {% set videoSource = dgUrl %}
+{% else %}
+  {% set videoSource = url %}
+{% endif %}
 <div class="video-wrapper" data-video-id="{{videoSource}}">
   <video width="1920" height="1080" preload="none" poster="{{poster}}" style="max-width:100%; height: auto;" controls>
     <source src="{{videoSource}}" type="video/mp4">{% if captionFile != null %}  <track label="{{captionLabel}}" kind="subtitles" srclang="{{locale}}" src="/images/subtitles/{{captionFile}}.vtt">{% endif %}

--- a/src/site/_includes/parts/macros.njk
+++ b/src/site/_includes/parts/macros.njk
@@ -110,7 +110,8 @@
 {% else %}
   {% set videoSource = url %}
 {% endif %}
-<div class="video-wrapper" data-video-id="{{videoSource}}">
+{% set videoAnchorId = videoSource | videoAnchor(page.url) %}
+<div class="video-wrapper"{% if videoAnchorId %} id="{{ videoAnchorId }}"{% endif %} data-video-id="{{videoSource}}">
   <video width="1920" height="1080" preload="none" poster="{{poster}}" style="max-width:100%; height: auto;" controls>
     <source src="{{videoSource}}" type="video/mp4">{% if captionFile != null %}  <track label="{{captionLabel}}" kind="subtitles" srclang="{{locale}}" src="/images/subtitles/{{captionFile}}.vtt">{% endif %}
     Your browser does not support the video tag.

--- a/src/site/_includes/parts/macros.njk
+++ b/src/site/_includes/parts/macros.njk
@@ -105,10 +105,13 @@
 {% endmacro %}
 
 {% macro video(url, poster, captionFile, captionLabel, locale, dgUrl="") %}
-<video width="1920" height="1080" preload="none" poster="{{poster}}" style="max-width:100%; height: auto;" controls>
-  <source src="{% if locale == "dg" %}{{dgUrl}}{% else %}{{url}}{% endif %}" type="video/mp4">{% if captionFile != null %}  <track label="{{captionLabel}}" kind="subtitles" srclang="{{locale}}" src="/images/subtitles/{{captionFile}}.vtt">{% endif %}
-  Your browser does not support the video tag.
-</video>
+{% set videoSource = locale == "dg" and dgUrl ? dgUrl : url %}
+<div class="video-wrapper" data-video-id="{{videoSource}}">
+  <video width="1920" height="1080" preload="none" poster="{{poster}}" style="max-width:100%; height: auto;" controls>
+    <source src="{{videoSource}}" type="video/mp4">{% if captionFile != null %}  <track label="{{captionLabel}}" kind="subtitles" srclang="{{locale}}" src="/images/subtitles/{{captionFile}}.vtt">{% endif %}
+    Your browser does not support the video tag.
+  </video>
+</div>
 {% endmacro %}
 
 {% macro h2(headline) %}

--- a/src/site/_includes/parts/video-library.njk
+++ b/src/site/_includes/parts/video-library.njk
@@ -3,19 +3,29 @@
 {% set notWatchedLabel = "Not watched yet" %}
 {% set openPageLabel = "Open page" %}
 {% set emptyLabel = "No videos found for this language." %}
+{% set gridLabel = "Grid view" %}
+{% set listLabel = "List view" %}
 
 {% if locale == "de" or locale == "dg" %}
   {% set watchedLabel = "Angesehen" %}
   {% set notWatchedLabel = "Noch nicht angesehen" %}
   {% set openPageLabel = "Seite öffnen" %}
   {% set emptyLabel = "Keine Videos für diese Sprache gefunden." %}
+  {% set gridLabel = "Kachelansicht" %}
+  {% set listLabel = "Listenansicht" %}
 {% endif %}
-  <div class="video-library">
+  <div class="video-library video-library--grid" data-locale="{{ locale }}">
   {% if not videos or videos.length == 0 %}
   <p class="video-library__loading">{{ emptyLabel }}</p>
   {% else %}
   <section class="video-library__locale">
-    <h2>{{ locale | upper }}</h2>
+    <div class="video-library__header">
+      <h2>{{ locale | upper }}</h2>
+      <div class="video-library__view-toggle" role="group" aria-label="{{ gridLabel }}/{{ listLabel }}">
+        <button type="button" class="video-library__view-btn is-active" data-view="grid">{{ gridLabel }}</button>
+        <button type="button" class="video-library__view-btn" data-view="list">{{ listLabel }}</button>
+      </div>
+    </div>
     <div class="video-library__grid">
       {% for video in videos %}
       <article class="video-library__card" data-video-id="{{ video.videoId }}"{% if video.anchorId %} data-video-anchor="{{ video.anchorId }}"{% endif %}>

--- a/src/site/_includes/parts/video-library.njk
+++ b/src/site/_includes/parts/video-library.njk
@@ -30,9 +30,6 @@
           <h3>{{ video.videoTitle }}</h3>
           <p class="video-library__page">{{ video.pageTitle }}</p>
           <span class="video-library__status" data-video-status data-watched-label="{{ watchedLabel }}" data-not-watched-label="{{ notWatchedLabel }}">{{ notWatchedLabel }}</span>
-          {% if video.videoSrc %}
-          <p class="video-library__source">{{ video.videoSrc }}</p>
-          {% endif %}
           <a href="{{ video.pageUrl }}{% if video.anchorId %}#{{ video.anchorId }}{% endif %}">{{ openPageLabel }}</a>
         </div>
       </article>

--- a/src/site/_includes/parts/video-library.njk
+++ b/src/site/_includes/parts/video-library.njk
@@ -18,7 +18,7 @@
     <h2>{{ locale | upper }}</h2>
     <div class="video-library__grid">
       {% for video in videos %}
-      <article class="video-library__card" data-video-id="{{ video.videoId }}">
+      <article class="video-library__card" data-video-id="{{ video.videoId }}"{% if video.anchorId %} data-video-anchor="{{ video.anchorId }}"{% endif %}>
         <div class="video-library__thumb">
           {% if video.poster %}
             <img src="{{ video.poster }}" alt="{{ video.pageTitle }} preview">
@@ -32,7 +32,7 @@
           {% if video.videoSrc %}
           <p class="video-library__source">{{ video.videoSrc }}</p>
           {% endif %}
-          <a href="{{ video.pageUrl }}">{{ openPageLabel }}</a>
+          <a href="{{ video.pageUrl }}{% if video.anchorId %}#{{ video.anchorId }}{% endif %}">{{ openPageLabel }}</a>
         </div>
       </article>
       {% endfor %}

--- a/src/site/_includes/parts/video-library.njk
+++ b/src/site/_includes/parts/video-library.njk
@@ -21,13 +21,14 @@
       <article class="video-library__card" data-video-id="{{ video.videoId }}"{% if video.anchorId %} data-video-anchor="{{ video.anchorId }}"{% endif %}>
         <div class="video-library__thumb">
           {% if video.poster %}
-            <img src="{{ video.poster }}" alt="{{ video.pageTitle }} preview">
+            <img src="{{ video.poster }}" alt="{{ video.videoTitle }} preview">
           {% else %}
             <div class="video-library__placeholder">No preview available</div>
           {% endif %}
         </div>
         <div class="video-library__body">
-          <h3>{{ video.pageTitle }}</h3>
+          <h3>{{ video.videoTitle }}</h3>
+          <p class="video-library__page">{{ video.pageTitle }}</p>
           <span class="video-library__status" data-video-status data-watched-label="{{ watchedLabel }}" data-not-watched-label="{{ notWatchedLabel }}">{{ notWatchedLabel }}</span>
           {% if video.videoSrc %}
           <p class="video-library__source">{{ video.videoSrc }}</p>

--- a/src/site/_includes/parts/video-library.njk
+++ b/src/site/_includes/parts/video-library.njk
@@ -1,0 +1,43 @@
+{% macro renderVideoLibrary(videos, locale) %}
+{% set watchedLabel = "Watched" %}
+{% set notWatchedLabel = "Not watched yet" %}
+{% set openPageLabel = "Open page" %}
+{% set emptyLabel = "No videos found for this language." %}
+
+{% if locale == "de" or locale == "dg" %}
+  {% set watchedLabel = "Angesehen" %}
+  {% set notWatchedLabel = "Noch nicht angesehen" %}
+  {% set openPageLabel = "Seite öffnen" %}
+  {% set emptyLabel = "Keine Videos für diese Sprache gefunden." %}
+{% endif %}
+  <div class="video-library">
+  {% if not videos or videos.length == 0 %}
+  <p class="video-library__loading">{{ emptyLabel }}</p>
+  {% else %}
+  <section class="video-library__locale">
+    <h2>{{ locale | upper }}</h2>
+    <div class="video-library__grid">
+      {% for video in videos %}
+      <article class="video-library__card" data-video-id="{{ video.videoId }}">
+        <div class="video-library__thumb">
+          {% if video.poster %}
+            <img src="{{ video.poster }}" alt="{{ video.pageTitle }} preview">
+          {% else %}
+            <div class="video-library__placeholder">No preview available</div>
+          {% endif %}
+        </div>
+        <div class="video-library__body">
+          <h3>{{ video.pageTitle }}</h3>
+          <span class="video-library__status" data-video-status data-watched-label="{{ watchedLabel }}" data-not-watched-label="{{ notWatchedLabel }}">{{ notWatchedLabel }}</span>
+          {% if video.videoSrc %}
+          <p class="video-library__source">{{ video.videoSrc }}</p>
+          {% endif %}
+          <a href="{{ video.pageUrl }}">{{ openPageLabel }}</a>
+        </div>
+      </article>
+      {% endfor %}
+    </div>
+  </section>
+  {% endif %}
+</div>
+{% endmacro %}

--- a/src/site/_includes/postcss/base.scss
+++ b/src/site/_includes/postcss/base.scss
@@ -269,6 +269,90 @@ video {
   display: inline-block;
 }
 
+.video-library {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.video-library__locale {
+  border-top: 1px solid rgba(0, 0, 0, 0.1);
+  padding-top: 12px;
+}
+
+.video-library__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 16px;
+  margin-top: 12px;
+}
+
+.video-library__card {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  border-radius: 8px;
+  padding: 12px;
+  background: rgba(0, 0, 0, 0.02);
+  height: 100%;
+}
+
+.video-library__card--watched {
+  border-color: #1b7a40;
+  box-shadow: 0 0 0 1px rgba(27, 122, 64, 0.2);
+}
+
+.video-library__thumb {
+  width: 100%;
+  aspect-ratio: 16/9;
+  border-radius: 6px;
+  overflow: hidden;
+  background: rgba(0, 0, 0, 0.04);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.video-library__thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.video-library__placeholder {
+  font-size: 0.9rem;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.video-library__body h3 {
+  margin: 0 0 6px;
+}
+
+.video-library__status {
+  display: inline-block;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.08);
+  font-size: 0.85rem;
+  margin-bottom: 6px;
+}
+
+.video-library__status--watched {
+  background: rgba(27, 122, 64, 0.12);
+  color: #1b7a40;
+}
+
+.video-library__source {
+  font-size: 0.9rem;
+  color: rgba(0, 0, 0, 0.7);
+  margin: 0 0 8px;
+}
+
+.video-library__loading {
+  font-style: italic;
+}
+
 /* CONTENT FORMATTING */
 
 main .col-2{

--- a/src/site/_includes/postcss/base.scss
+++ b/src/site/_includes/postcss/base.scss
@@ -329,6 +329,12 @@ video {
   margin: 0 0 6px;
 }
 
+.video-library__page {
+  margin: 0 0 8px;
+  font-size: 0.95rem;
+  color: rgba(0, 0, 0, 0.8);
+}
+
 .video-library__status {
   display: inline-block;
   padding: 4px 10px;

--- a/src/site/_includes/postcss/base.scss
+++ b/src/site/_includes/postcss/base.scss
@@ -275,6 +275,36 @@ video {
   gap: 32px;
 }
 
+.video-library__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.video-library__view-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.video-library__view-btn {
+  border: 1px solid rgba(0, 0, 0, 0.15);
+  background: rgba(0, 0, 0, 0.03);
+  padding: 6px 10px;
+  border-radius: 6px;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.video-library__view-btn.is-active {
+  background: rgba(0, 0, 0, 0.08);
+  border-color: rgba(0, 0, 0, 0.3);
+  color: #0f4332;
+}
+
 .video-library__locale {
   border-top: 1px solid rgba(0, 0, 0, 0.1);
   padding-top: 12px;
@@ -296,6 +326,46 @@ video {
   padding: 12px;
   background: rgba(0, 0, 0, 0.02);
   height: 100%;
+}
+
+.video-library--list .video-library__grid {
+  display: flex;
+  flex-direction: column;
+}
+
+.video-library--list .video-library__card {
+  flex-direction: row;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+}
+
+.video-library--list .video-library__thumb {
+  width: 140px;
+  min-width: 140px;
+  max-width: 140px;
+  aspect-ratio: 16/9;
+}
+
+.video-library--list .video-library__body {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  align-items: center;
+  gap: 6px 16px;
+  width: 100%;
+}
+
+.video-library--list .video-library__body h3 {
+  margin-bottom: 0;
+}
+
+.video-library--list .video-library__page {
+  margin-bottom: 0;
+}
+
+.video-library--list .video-library__status {
+  margin-bottom: 0;
+  justify-self: start;
 }
 
 .video-library__card--watched {
@@ -1151,6 +1221,18 @@ h3.inspiration {
   .video-library__card {
     border-color: rgba(255, 255, 255, 0.2);
     background: rgba(255, 255, 255, 0.04);
+  }
+
+  .video-library__view-btn {
+    border-color: rgba(255, 255, 255, 0.25);
+    background: rgba(255, 255, 255, 0.08);
+    color: $dark-font;
+  }
+
+  .video-library__view-btn.is-active {
+    background: rgba(255, 255, 255, 0.16);
+    border-color: rgba(255, 255, 255, 0.4);
+    color: $dark-font;
   }
 
   .video-library__card--watched {

--- a/src/site/_includes/postcss/base.scss
+++ b/src/site/_includes/postcss/base.scss
@@ -1149,4 +1149,44 @@ h3.inspiration {
       background-color: rgba(170, 170, 170, 1);
     }
   }
+
+  .video-library__locale {
+    border-top-color: rgba(255, 255, 255, 0.2);
+  }
+
+  .video-library__card {
+    border-color: rgba(255, 255, 255, 0.2);
+    background: rgba(255, 255, 255, 0.04);
+  }
+
+  .video-library__card--watched {
+    border-color: rgba(20, 168, 115, 0.65);
+    box-shadow: 0 0 0 1px rgba(20, 168, 115, 0.35);
+  }
+
+  .video-library__thumb {
+    background: rgba(255, 255, 255, 0.06);
+  }
+
+  .video-library__placeholder {
+    color: rgba(255, 255, 255, 0.75);
+  }
+
+  .video-library__page {
+    color: rgba(255, 255, 255, 0.8);
+  }
+
+  .video-library__status {
+    background: rgba(255, 255, 255, 0.1);
+    color: $dark-font;
+  }
+
+  .video-library__status--watched {
+    background: rgba(20, 168, 115, 0.18);
+    color: $dark-font;
+  }
+
+  .video-library__source {
+    color: rgba(255, 255, 255, 0.8);
+  }
 }

--- a/src/site/_includes/postcss/base.scss
+++ b/src/site/_includes/postcss/base.scss
@@ -353,6 +353,8 @@ video {
   font-size: 0.9rem;
   color: rgba(0, 0, 0, 0.7);
   margin: 0 0 8px;
+  word-break: break-word;
+  overflow-wrap: anywhere;
 }
 
 .video-library__loading {

--- a/src/site/_includes/postcss/base.scss
+++ b/src/site/_includes/postcss/base.scss
@@ -349,14 +349,6 @@ video {
   color: #1b7a40;
 }
 
-.video-library__source {
-  font-size: 0.9rem;
-  color: rgba(0, 0, 0, 0.7);
-  margin: 0 0 8px;
-  word-break: break-word;
-  overflow-wrap: anywhere;
-}
-
 .video-library__loading {
   font-style: italic;
 }
@@ -1188,7 +1180,4 @@ h3.inspiration {
     color: $dark-font;
   }
 
-  .video-library__source {
-    color: rgba(255, 255, 255, 0.8);
-  }
 }

--- a/src/site/_includes/postcss/base.scss
+++ b/src/site/_includes/postcss/base.scss
@@ -282,9 +282,21 @@ video {
 
 .video-library__grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  grid-template-columns: repeat(1, minmax(0, 1fr));
   gap: 16px;
   margin-top: 12px;
+}
+
+@media screen and (min-width: 640px) {
+  .video-library__grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media screen and (min-width: 1024px) {
+  .video-library__grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
 }
 
 .video-library__card {

--- a/src/site/_includes/postcss/base.scss
+++ b/src/site/_includes/postcss/base.scss
@@ -25,6 +25,11 @@ body {
   flex-direction: row;
 }
 
+.video-library-page #container {
+  width: 95%;
+  max-width: 1400px;
+}
+
 main {
   flex-grow: 1;
   /* width: 0px; */

--- a/src/site/_includes/postcss/base.scss
+++ b/src/site/_includes/postcss/base.scss
@@ -25,11 +25,6 @@ body {
   flex-direction: row;
 }
 
-.video-library-page #container {
-  width: 95%;
-  max-width: 1400px;
-}
-
 main {
   flex-grow: 1;
   /* width: 0px; */
@@ -287,21 +282,9 @@ video {
 
 .video-library__grid {
   display: grid;
-  grid-template-columns: repeat(1, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   gap: 16px;
   margin-top: 12px;
-}
-
-@media screen and (min-width: 640px) {
-  .video-library__grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-}
-
-@media screen and (min-width: 1024px) {
-  .video-library__grid {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-  }
 }
 
 .video-library__card {

--- a/src/site/_includes/postcss/base.scss
+++ b/src/site/_includes/postcss/base.scss
@@ -241,6 +241,34 @@ video {
   margin-bottom:15px;
 }
 
+.video-wrapper {
+  position: relative;
+  display: inline-block;
+  width: 100%;
+}
+
+.video-wrapper video {
+  display: block;
+  width: 100%;
+}
+
+.video-status {
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  background-color: rgba(0, 0, 0, 0.75);
+  color: #fff;
+  padding: 6px 10px;
+  border-radius: 4px;
+  font-size: 0.9rem;
+  letter-spacing: 0.5px;
+  display: none;
+}
+
+.video-wrapper.video-watched .video-status {
+  display: inline-block;
+}
+
 /* CONTENT FORMATTING */
 
 main .col-2{

--- a/src/site/de/videos.md
+++ b/src/site/de/videos.md
@@ -9,10 +9,11 @@ eleventyNavigation:
 locale: de
 ---
 
+{% from "../_includes/parts/video-library.njk" import renderVideoLibrary %}
+{% set videos = collections.videoLibrary | videosByLocale(locale) %}
+
 <p>Diese Seite sammelt alle eingebetteten Videos der Website, damit du schnell sehen kannst, welche Inhalte es gibt und welche du bereits angesehen hast.</p>
 
-<script id="nav-data" type="application/json">{{ collections.all | eleventyNavigation | dump | safe }}</script>
-<div class="video-library" data-video-library>
-  <p class="video-library__loading">Videos werden gesammelt …</p>
-</div>
+{{ renderVideoLibrary(videos, locale) }}
+
 <script src="/js/video-library.js"></script>

--- a/src/site/de/videos.md
+++ b/src/site/de/videos.md
@@ -1,0 +1,18 @@
+---
+title: Videoübersicht
+layout: default
+eleventyNavigation:
+  title: Videoübersicht
+  key: de_video_library
+  parent: de
+  order: 200
+locale: de
+---
+
+<p>Diese Seite sammelt alle eingebetteten Videos der Website, damit du schnell sehen kannst, welche Inhalte es gibt und welche du bereits angesehen hast.</p>
+
+<script id="nav-data" type="application/json">{{ collections.all | eleventyNavigation | dump | safe }}</script>
+<div class="video-library" data-video-library>
+  <p class="video-library__loading">Videos werden gesammelt …</p>
+</div>
+<script src="/js/video-library.js"></script>

--- a/src/site/dg/videos.md
+++ b/src/site/dg/videos.md
@@ -9,10 +9,11 @@ eleventyNavigation:
 locale: dg
 ---
 
+{% from "../_includes/parts/video-library.njk" import renderVideoLibrary %}
+{% set videos = collections.videoLibrary | videosByLocale(locale) %}
+
 <p>This page collects every embedded video from the site so you can quickly see what is available and which clips you have already watched.</p>
 
-<script id="nav-data" type="application/json">{{ collections.all | eleventyNavigation | dump | safe }}</script>
-<div class="video-library" data-video-library>
-  <p class="video-library__loading">Collecting videos…</p>
-</div>
+{{ renderVideoLibrary(videos, locale) }}
+
 <script src="/js/video-library.js"></script>

--- a/src/site/dg/videos.md
+++ b/src/site/dg/videos.md
@@ -1,0 +1,18 @@
+---
+title: Video Library
+layout: default
+eleventyNavigation:
+  title: Video Library
+  key: dg_video_library
+  parent: dg
+  order: 200
+locale: dg
+---
+
+<p>This page collects every embedded video from the site so you can quickly see what is available and which clips you have already watched.</p>
+
+<script id="nav-data" type="application/json">{{ collections.all | eleventyNavigation | dump | safe }}</script>
+<div class="video-library" data-video-library>
+  <p class="video-library__loading">Collecting videos…</p>
+</div>
+<script src="/js/video-library.js"></script>

--- a/src/site/en/videos.md
+++ b/src/site/en/videos.md
@@ -1,0 +1,18 @@
+---
+title: Video Library
+layout: default
+eleventyNavigation:
+  title: Video Library
+  key: en_video_library
+  parent: en
+  order: 200
+locale: en
+---
+
+<p>This page collects every embedded video from the site so you can quickly see what is available and which clips you have already watched.</p>
+
+<script id="nav-data" type="application/json">{{ collections.all | eleventyNavigation | dump | safe }}</script>
+<div class="video-library" data-video-library>
+  <p class="video-library__loading">Collecting videos…</p>
+</div>
+<script src="/js/video-library.js"></script>

--- a/src/site/en/videos.md
+++ b/src/site/en/videos.md
@@ -9,10 +9,11 @@ eleventyNavigation:
 locale: en
 ---
 
+{% from "../_includes/parts/video-library.njk" import renderVideoLibrary %}
+{% set videos = collections.videoLibrary | videosByLocale(locale) %}
+
 <p>This page collects every embedded video from the site so you can quickly see what is available and which clips you have already watched.</p>
 
-<script id="nav-data" type="application/json">{{ collections.all | eleventyNavigation | dump | safe }}</script>
-<div class="video-library" data-video-library>
-  <p class="video-library__loading">Collecting videos…</p>
-</div>
+{{ renderVideoLibrary(videos, locale) }}
+
 <script src="/js/video-library.js"></script>

--- a/src/site/js/main.js
+++ b/src/site/js/main.js
@@ -14,3 +14,46 @@ document.querySelectorAll('#nav nav h5').forEach(header => {
     }
   });
 });
+
+const STORAGE_KEY = 'watchedVideos';
+
+const getStoredVideos = () => {
+  try {
+    return JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]');
+  } catch (error) {
+    return [];
+  }
+};
+
+const watchedVideos = new Set(getStoredVideos());
+
+const saveWatchedVideos = () => {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify([...watchedVideos]));
+};
+
+document.querySelectorAll('.video-wrapper[data-video-id]').forEach(wrapper => {
+  const videoId = wrapper.dataset.videoId;
+  const videoElement = wrapper.querySelector('video');
+
+  if (!videoId || !videoElement) {
+    return;
+  }
+
+  let badge = wrapper.querySelector('.video-status');
+  if (!badge) {
+    badge = document.createElement('div');
+    badge.className = 'video-status';
+    badge.textContent = 'Watched';
+    wrapper.appendChild(badge);
+  }
+
+  if (watchedVideos.has(videoId)) {
+    wrapper.classList.add('video-watched');
+  }
+
+  videoElement.addEventListener('ended', () => {
+    watchedVideos.add(videoId);
+    saveWatchedVideos();
+    wrapper.classList.add('video-watched');
+  });
+});

--- a/src/site/js/main.js
+++ b/src/site/js/main.js
@@ -27,8 +27,22 @@ const getStoredVideos = () => {
 
 const watchedVideos = new Set(getStoredVideos());
 
+const hasWatchedVideo = videoId => watchedVideos.has(videoId);
+
 const saveWatchedVideos = () => {
   localStorage.setItem(STORAGE_KEY, JSON.stringify([...watchedVideos]));
+};
+
+const markVideoIdWatched = videoId => {
+  if (!videoId || watchedVideos.has(videoId)) return;
+  watchedVideos.add(videoId);
+  saveWatchedVideos();
+};
+
+window.videoProgress = {
+  hasWatched: hasWatchedVideo,
+  markWatched: markVideoIdWatched,
+  getWatchedIds: () => [...watchedVideos],
 };
 
 document.querySelectorAll('.video-wrapper[data-video-id]').forEach(wrapper => {
@@ -47,17 +61,16 @@ document.querySelectorAll('.video-wrapper[data-video-id]').forEach(wrapper => {
     wrapper.appendChild(badge);
   }
 
-  if (watchedVideos.has(videoId)) {
+  if (hasWatchedVideo(videoId)) {
     wrapper.classList.add('video-watched');
   }
 
-  let isMarkedWatched = watchedVideos.has(videoId);
+  let isMarkedWatched = hasWatchedVideo(videoId);
 
   const markWatched = () => {
     if (isMarkedWatched) return;
     isMarkedWatched = true;
-    watchedVideos.add(videoId);
-    saveWatchedVideos();
+    markVideoIdWatched(videoId);
     wrapper.classList.add('video-watched');
   };
 

--- a/src/site/js/main.js
+++ b/src/site/js/main.js
@@ -51,9 +51,21 @@ document.querySelectorAll('.video-wrapper[data-video-id]').forEach(wrapper => {
     wrapper.classList.add('video-watched');
   }
 
-  videoElement.addEventListener('ended', () => {
+  let isMarkedWatched = watchedVideos.has(videoId);
+
+  const markWatched = () => {
+    if (isMarkedWatched) return;
+    isMarkedWatched = true;
     watchedVideos.add(videoId);
     saveWatchedVideos();
     wrapper.classList.add('video-watched');
+  };
+
+  videoElement.addEventListener('timeupdate', () => {
+    if (videoElement.duration && videoElement.currentTime >= videoElement.duration - 10) {
+      markWatched();
+    }
   });
+
+  videoElement.addEventListener('ended', markWatched);
 });

--- a/src/site/js/video-library.js
+++ b/src/site/js/video-library.js
@@ -1,0 +1,164 @@
+const navDataElement = document.getElementById('nav-data');
+const libraryContainer = document.querySelector('[data-video-library]');
+
+if (navDataElement && libraryContainer) {
+  const LOCALES = ['de', 'en', 'dg'];
+  const navData = JSON.parse(navDataElement.textContent || '[]');
+
+  const flattenNav = entries => entries.reduce((urls, entry) => {
+    if (entry.url) {
+      urls.push(entry.url);
+    }
+    if (entry.children?.length) {
+      urls.push(...flattenNav(entry.children));
+    }
+    return urls;
+  }, []);
+
+  const pageMap = LOCALES.reduce((map, locale) => {
+    const rootEntry = navData.find(entry => entry.key === locale);
+    if (rootEntry) {
+      map[locale] = Array.from(new Set(flattenNav(rootEntry.children || [])));
+    }
+    return map;
+  }, {});
+
+  const renderStatus = (videoId) => {
+    const status = document.createElement('span');
+    const hasWatched = window.videoProgress?.hasWatched?.(videoId) ?? false;
+    status.className = 'video-library__status';
+    status.textContent = hasWatched ? 'Watched' : 'Not watched yet';
+    if (hasWatched) {
+      status.classList.add('video-library__status--watched');
+    }
+    return status;
+  };
+
+  const renderCard = (video) => {
+    const card = document.createElement('article');
+    card.className = 'video-library__card';
+
+    if (window.videoProgress?.hasWatched?.(video.videoId)) {
+      card.classList.add('video-library__card--watched');
+    }
+
+    const thumb = document.createElement('div');
+    thumb.className = 'video-library__thumb';
+
+    if (video.poster) {
+      const img = document.createElement('img');
+      img.src = video.poster;
+      img.alt = `${video.pageTitle} preview`;
+      thumb.appendChild(img);
+    } else {
+      const placeholder = document.createElement('div');
+      placeholder.className = 'video-library__placeholder';
+      placeholder.textContent = 'No preview available';
+      thumb.appendChild(placeholder);
+    }
+
+    const body = document.createElement('div');
+    body.className = 'video-library__body';
+
+    const title = document.createElement('h3');
+    title.textContent = video.pageTitle;
+
+    const link = document.createElement('a');
+    link.href = video.pageUrl;
+    link.textContent = 'Open page';
+
+    const source = document.createElement('p');
+    source.className = 'video-library__source';
+    source.textContent = video.videoSrc || video.videoId;
+
+    body.appendChild(title);
+    body.appendChild(renderStatus(video.videoId));
+    body.appendChild(source);
+    body.appendChild(link);
+
+    card.appendChild(thumb);
+    card.appendChild(body);
+
+    return card;
+  };
+
+  const renderLocale = (locale, videos) => {
+    const localeSection = document.createElement('section');
+    localeSection.className = 'video-library__locale';
+
+    const heading = document.createElement('h2');
+    heading.textContent = locale.toUpperCase();
+    localeSection.appendChild(heading);
+
+    if (!videos.length) {
+      const empty = document.createElement('p');
+      empty.textContent = 'No videos found for this language.';
+      localeSection.appendChild(empty);
+      return localeSection;
+    }
+
+    const grid = document.createElement('div');
+    grid.className = 'video-library__grid';
+
+    videos.forEach(video => {
+      grid.appendChild(renderCard(video));
+    });
+
+    localeSection.appendChild(grid);
+    return localeSection;
+  };
+
+  const fetchVideosForLocale = async (locale) => {
+    const urls = pageMap[locale] || [];
+    const entries = [];
+
+    for (const url of urls) {
+      const fullUrl = new URL(url, window.location.origin).href;
+      try {
+        const response = await fetch(fullUrl);
+        if (!response.ok) continue;
+
+        const text = await response.text();
+        const doc = new DOMParser().parseFromString(text, 'text/html');
+        const pageTitle = doc.querySelector('h1')?.textContent?.trim() || fullUrl;
+
+        doc.querySelectorAll('.video-wrapper[data-video-id]').forEach(wrapper => {
+          const videoId = wrapper.dataset.videoId;
+          if (!videoId) return;
+
+          const videoElement = wrapper.querySelector('video');
+          const poster = videoElement?.getAttribute('poster') || '';
+          const videoSrc = videoElement?.querySelector('source')?.getAttribute('src') || '';
+
+          entries.push({ locale, pageTitle, pageUrl: fullUrl, videoId, poster, videoSrc });
+        });
+      } catch (error) {
+        console.warn('Unable to extract videos from', fullUrl, error);
+      }
+    }
+
+    return entries;
+  };
+
+  const renderLibrary = (library) => {
+    libraryContainer.innerHTML = '';
+    LOCALES.forEach(locale => {
+      libraryContainer.appendChild(renderLocale(locale, library.filter(video => video.locale === locale)));
+    });
+  };
+
+  const loadLibrary = async () => {
+    libraryContainer.innerHTML = '<p class="video-library__loading">Collecting videos…</p>';
+    const collected = [];
+
+    for (const locale of LOCALES) {
+      const videos = await fetchVideosForLocale(locale);
+      collected.push(...videos);
+    }
+
+    collected.sort((a, b) => a.pageTitle.localeCompare(b.pageTitle));
+    renderLibrary(collected);
+  };
+
+  loadLibrary();
+}

--- a/src/site/js/video-library.js
+++ b/src/site/js/video-library.js
@@ -1,4 +1,6 @@
 const cards = document.querySelectorAll('.video-library__card[data-video-id]');
+const library = document.querySelector('.video-library');
+const viewButtons = document.querySelectorAll('.video-library__view-btn[data-view]');
 
 const updateCardStatus = (card) => {
   const videoId = card.dataset.videoId;
@@ -18,6 +20,49 @@ const updateCardStatus = (card) => {
     status.textContent = notWatchedLabel;
   }
 };
+
+const setView = (view) => {
+  if (!library) return;
+  const allowedViews = ['grid', 'list'];
+  const nextView = allowedViews.includes(view) ? view : 'grid';
+  library.classList.remove('video-library--grid', 'video-library--list');
+  library.classList.add(`video-library--${nextView}`);
+
+  viewButtons.forEach((btn) => {
+    if (btn.dataset.view === nextView) {
+      btn.classList.add('is-active');
+    } else {
+      btn.classList.remove('is-active');
+    }
+  });
+
+  const locale = library.dataset.locale || 'default';
+  try {
+    localStorage.setItem(`videoLibraryView:${locale}`, nextView);
+  } catch (err) {
+    // ignore storage errors
+  }
+};
+
+const applySavedView = () => {
+  if (!library) return;
+  const locale = library.dataset.locale || 'default';
+  try {
+    const saved = localStorage.getItem(`videoLibraryView:${locale}`);
+    if (saved) {
+      setView(saved);
+    }
+  } catch (err) {
+    // ignore storage errors
+  }
+};
+
+if (viewButtons.length && library) {
+  viewButtons.forEach((btn) => {
+    btn.addEventListener('click', () => setView(btn.dataset.view));
+  });
+  applySavedView();
+}
 
 if (cards.length) {
   cards.forEach(updateCardStatus);

--- a/src/site/js/video-library.js
+++ b/src/site/js/video-library.js
@@ -1,164 +1,24 @@
-const navDataElement = document.getElementById('nav-data');
-const libraryContainer = document.querySelector('[data-video-library]');
+const cards = document.querySelectorAll('.video-library__card[data-video-id]');
 
-if (navDataElement && libraryContainer) {
-  const LOCALES = ['de', 'en', 'dg'];
-  const navData = JSON.parse(navDataElement.textContent || '[]');
+const updateCardStatus = (card) => {
+  const videoId = card.dataset.videoId;
+  const status = card.querySelector('[data-video-status]');
+  const watched = window.videoProgress?.hasWatched?.(videoId) ?? false;
+  const watchedLabel = status?.dataset?.watchedLabel || 'Watched';
+  const notWatchedLabel = status?.dataset?.notWatchedLabel || 'Not watched yet';
 
-  const flattenNav = entries => entries.reduce((urls, entry) => {
-    if (entry.url) {
-      urls.push(entry.url);
-    }
-    if (entry.children?.length) {
-      urls.push(...flattenNav(entry.children));
-    }
-    return urls;
-  }, []);
-
-  const pageMap = LOCALES.reduce((map, locale) => {
-    const rootEntry = navData.find(entry => entry.key === locale);
-    if (rootEntry) {
-      map[locale] = Array.from(new Set(flattenNav(rootEntry.children || [])));
-    }
-    return map;
-  }, {});
-
-  const renderStatus = (videoId) => {
-    const status = document.createElement('span');
-    const hasWatched = window.videoProgress?.hasWatched?.(videoId) ?? false;
-    status.className = 'video-library__status';
-    status.textContent = hasWatched ? 'Watched' : 'Not watched yet';
-    if (hasWatched) {
+  if (watched) {
+    card.classList.add('video-library__card--watched');
+    if (status) {
       status.classList.add('video-library__status--watched');
+      status.textContent = watchedLabel;
     }
-    return status;
-  };
+  } else if (status) {
+    status.classList.remove('video-library__status--watched');
+    status.textContent = notWatchedLabel;
+  }
+};
 
-  const renderCard = (video) => {
-    const card = document.createElement('article');
-    card.className = 'video-library__card';
-
-    if (window.videoProgress?.hasWatched?.(video.videoId)) {
-      card.classList.add('video-library__card--watched');
-    }
-
-    const thumb = document.createElement('div');
-    thumb.className = 'video-library__thumb';
-
-    if (video.poster) {
-      const img = document.createElement('img');
-      img.src = video.poster;
-      img.alt = `${video.pageTitle} preview`;
-      thumb.appendChild(img);
-    } else {
-      const placeholder = document.createElement('div');
-      placeholder.className = 'video-library__placeholder';
-      placeholder.textContent = 'No preview available';
-      thumb.appendChild(placeholder);
-    }
-
-    const body = document.createElement('div');
-    body.className = 'video-library__body';
-
-    const title = document.createElement('h3');
-    title.textContent = video.pageTitle;
-
-    const link = document.createElement('a');
-    link.href = video.pageUrl;
-    link.textContent = 'Open page';
-
-    const source = document.createElement('p');
-    source.className = 'video-library__source';
-    source.textContent = video.videoSrc || video.videoId;
-
-    body.appendChild(title);
-    body.appendChild(renderStatus(video.videoId));
-    body.appendChild(source);
-    body.appendChild(link);
-
-    card.appendChild(thumb);
-    card.appendChild(body);
-
-    return card;
-  };
-
-  const renderLocale = (locale, videos) => {
-    const localeSection = document.createElement('section');
-    localeSection.className = 'video-library__locale';
-
-    const heading = document.createElement('h2');
-    heading.textContent = locale.toUpperCase();
-    localeSection.appendChild(heading);
-
-    if (!videos.length) {
-      const empty = document.createElement('p');
-      empty.textContent = 'No videos found for this language.';
-      localeSection.appendChild(empty);
-      return localeSection;
-    }
-
-    const grid = document.createElement('div');
-    grid.className = 'video-library__grid';
-
-    videos.forEach(video => {
-      grid.appendChild(renderCard(video));
-    });
-
-    localeSection.appendChild(grid);
-    return localeSection;
-  };
-
-  const fetchVideosForLocale = async (locale) => {
-    const urls = pageMap[locale] || [];
-    const entries = [];
-
-    for (const url of urls) {
-      const fullUrl = new URL(url, window.location.origin).href;
-      try {
-        const response = await fetch(fullUrl);
-        if (!response.ok) continue;
-
-        const text = await response.text();
-        const doc = new DOMParser().parseFromString(text, 'text/html');
-        const pageTitle = doc.querySelector('h1')?.textContent?.trim() || fullUrl;
-
-        doc.querySelectorAll('.video-wrapper[data-video-id]').forEach(wrapper => {
-          const videoId = wrapper.dataset.videoId;
-          if (!videoId) return;
-
-          const videoElement = wrapper.querySelector('video');
-          const poster = videoElement?.getAttribute('poster') || '';
-          const videoSrc = videoElement?.querySelector('source')?.getAttribute('src') || '';
-
-          entries.push({ locale, pageTitle, pageUrl: fullUrl, videoId, poster, videoSrc });
-        });
-      } catch (error) {
-        console.warn('Unable to extract videos from', fullUrl, error);
-      }
-    }
-
-    return entries;
-  };
-
-  const renderLibrary = (library) => {
-    libraryContainer.innerHTML = '';
-    LOCALES.forEach(locale => {
-      libraryContainer.appendChild(renderLocale(locale, library.filter(video => video.locale === locale)));
-    });
-  };
-
-  const loadLibrary = async () => {
-    libraryContainer.innerHTML = '<p class="video-library__loading">Collecting videos…</p>';
-    const collected = [];
-
-    for (const locale of LOCALES) {
-      const videos = await fetchVideosForLocale(locale);
-      collected.push(...videos);
-    }
-
-    collected.sort((a, b) => a.pageTitle.localeCompare(b.pageTitle));
-    renderLibrary(collected);
-  };
-
-  loadLibrary();
+if (cards.length) {
+  cards.forEach(updateCardStatus);
 }


### PR DESCRIPTION
## Summary
- wrap embedded videos in a trackable container so each clip has an id
- style an overlay badge to highlight watched videos
- add client-side logic to record watched videos in localStorage and show the badge across visits

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69316aeb73c48323bd04965ad1b3d971)