### PR TITLE
Simplify video library header and compact list view

### DIFF
--- a/src/site/_includes/parts/video-library.njk
+++ b/src/site/_includes/parts/video-library.njk
@@ -1,7 +1,6 @@
 {% macro renderVideoLibrary(videos, locale) %}
 {% set watchedLabel = "Watched" %}
 {% set notWatchedLabel = "Not watched yet" %}
-{% set openPageLabel = "Open page" %}
 {% set emptyLabel = "No videos found for this language." %}
 {% set gridLabel = "Grid view" %}
 {% set listLabel = "List view" %}
@@ -9,7 +8,6 @@
 {% if locale == "de" or locale == "dg" %}
   {% set watchedLabel = "Angesehen" %}
   {% set notWatchedLabel = "Noch nicht angesehen" %}
-  {% set openPageLabel = "Seite öffnen" %}
   {% set emptyLabel = "Keine Videos für diese Sprache gefunden." %}
   {% set gridLabel = "Kachelansicht" %}
   {% set listLabel = "Listenansicht" %}
@@ -20,7 +18,6 @@
   {% else %}
   <section class="video-library__locale">
     <div class="video-library__header">
-      <h2>{{ locale | upper }}</h2>
       <div class="video-library__view-toggle" role="group" aria-label="{{ gridLabel }}/{{ listLabel }}">
         <button type="button" class="video-library__view-btn is-active" data-view="grid">{{ gridLabel }}</button>
         <button type="button" class="video-library__view-btn" data-view="list">{{ listLabel }}</button>
@@ -28,7 +25,7 @@
     </div>
     <div class="video-library__grid">
       {% for video in videos %}
-      <article class="video-library__card" data-video-id="{{ video.videoId }}"{% if video.anchorId %} data-video-anchor="{{ video.anchorId }}"{% endif %}>
+      <a class="video-library__card" href="{{ video.pageUrl }}{% if video.anchorId %}#{{ video.anchorId }}{% endif %}" data-video-id="{{ video.videoId }}"{% if video.anchorId %} data-video-anchor="{{ video.anchorId }}"{% endif %}>
         <div class="video-library__thumb">
           {% if video.poster %}
             <img src="{{ video.poster }}" alt="{{ video.videoTitle }} preview">
@@ -37,12 +34,11 @@
           {% endif %}
         </div>
         <div class="video-library__body">
-          <h3>{{ video.videoTitle }}</h3>
           <p class="video-library__page">{{ video.pageTitle }}</p>
+          <h3>{{ video.videoTitle }}</h3>
           <span class="video-library__status" data-video-status data-watched-label="{{ watchedLabel }}" data-not-watched-label="{{ notWatchedLabel }}">{{ notWatchedLabel }}</span>
-          <a href="{{ video.pageUrl }}{% if video.anchorId %}#{{ video.anchorId }}{% endif %}">{{ openPageLabel }}</a>
         </div>
-      </article>
+      </a>
       {% endfor %}
     </div>
   </section>

--- a/src/site/_includes/postcss/base.scss
+++ b/src/site/_includes/postcss/base.scss
@@ -272,14 +272,14 @@ video {
 .video-library {
   display: flex;
   flex-direction: column;
-  gap: 32px;
+  gap: 28px;
 }
 
 .video-library__header {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 16px;
+  justify-content: flex-end;
+  gap: 12px;
   flex-wrap: wrap;
 }
 
@@ -307,14 +307,14 @@ video {
 
 .video-library__locale {
   border-top: 1px solid rgba(0, 0, 0, 0.1);
-  padding-top: 12px;
+  padding-top: 8px;
 }
 
 .video-library__grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 16px;
-  margin-top: 12px;
+  gap: 12px;
+  margin-top: 8px;
 }
 
 .video-library__card {
@@ -323,9 +323,23 @@ video {
   gap: 10px;
   border: 1px solid rgba(0, 0, 0, 0.12);
   border-radius: 8px;
-  padding: 12px;
+  padding: 10px;
   background: rgba(0, 0, 0, 0.02);
   height: 100%;
+  color: inherit;
+  text-decoration: none;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.1s ease;
+}
+
+.video-library__card:hover,
+.video-library__card:focus-visible {
+  border-color: rgba(0, 0, 0, 0.24);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
+}
+
+.video-library__card:focus-visible {
+  outline: none;
+  transform: translateY(-1px);
 }
 
 .video-library--list .video-library__grid {
@@ -336,14 +350,14 @@ video {
 .video-library--list .video-library__card {
   flex-direction: row;
   align-items: center;
-  gap: 12px;
-  padding: 10px 12px;
+  gap: 10px;
+  padding: 8px 10px;
 }
 
 .video-library--list .video-library__thumb {
-  width: 140px;
-  min-width: 140px;
-  max-width: 140px;
+  width: 128px;
+  min-width: 128px;
+  max-width: 128px;
   aspect-ratio: 16/9;
 }
 
@@ -351,7 +365,7 @@ video {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   align-items: center;
-  gap: 6px 16px;
+  gap: 6px 12px;
   width: 100%;
 }
 
@@ -396,22 +410,22 @@ video {
 }
 
 .video-library__body h3 {
-  margin: 0 0 6px;
+  margin: 0 0 4px;
 }
 
 .video-library__page {
-  margin: 0 0 8px;
+  margin: 0 0 4px;
   font-size: 0.95rem;
   color: rgba(0, 0, 0, 0.8);
 }
 
 .video-library__status {
   display: inline-block;
-  padding: 4px 10px;
+  padding: 3px 8px;
   border-radius: 999px;
   background: rgba(0, 0, 0, 0.08);
   font-size: 0.85rem;
-  margin-bottom: 6px;
+  margin-bottom: 4px;
 }
 
 .video-library__status--watched {
@@ -1221,6 +1235,12 @@ h3.inspiration {
   .video-library__card {
     border-color: rgba(255, 255, 255, 0.2);
     background: rgba(255, 255, 255, 0.04);
+  }
+
+  .video-library__card:hover,
+  .video-library__card:focus-visible {
+    border-color: rgba(255, 255, 255, 0.35);
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.25);
   }
 
   .video-library__view-btn {


### PR DESCRIPTION
## Summary
- remove the locale heading so the video library tiles start with the controls
- tighten card spacing and padding to make the grid and list views more compact

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932937769888323b8fda906c22aefb3)